### PR TITLE
refactor: improve quiz session schema with enum

### DIFF
--- a/scripts/gen-samples.ts
+++ b/scripts/gen-samples.ts
@@ -6,7 +6,11 @@ import { PDFDocument, rgb, StandardFonts } from 'pdf-lib';
 
 import { type Article } from '@models/article-schema.ts';
 import { type Course } from '@models/course-schema.ts';
-import { type Quiz } from '@models/quiz-schema.ts';
+import {
+  QuizSessionEnum,
+  type Quiz,
+  type QuizSession,
+} from '@models/quiz-schema.ts';
 import { type User } from '@models/user-schema.ts';
 
 async function readListJsonFile<T>(filePath: string): Promise<T[]> {
@@ -77,14 +81,9 @@ function getRandomUser(users: User[]): User {
   return users[Math.floor(Math.random() * users.length)];
 }
 
-function getRandomSection():
-  | 'first'
-  | 'second'
-  | 'midterm'
-  | 'final'
-  | 'other' {
-  const sections = ['first', 'second', 'midterm', 'final', 'other'] as const;
-  return sections[Math.floor(Math.random() * sections.length)];
+function getRandomSection(): QuizSession {
+  const values = Object.values(QuizSessionEnum);
+  return values[Math.floor(Math.random() * values.length)];
 }
 
 function generateArticles(

--- a/src/models/quiz-schema.ts
+++ b/src/models/quiz-schema.ts
@@ -5,9 +5,21 @@ import { z } from 'zod';
 
 import { ZUuidSchema } from './util-schema.ts';
 
+const ZQuizSessionSchema = z.enum([
+  'midterm',
+  'final',
+  'first',
+  'second',
+  'other',
+]);
+
+type QuizSession = z.infer<typeof ZQuizSessionSchema>;
+
+const QuizSessionEnum = ZQuizSessionSchema.enum;
+
 const ZQuizSchema = z.object({
   _id: ZUuidSchema,
-  session: z.enum(['midterm', 'final', 'first', 'second', 'other']),
+  session: ZQuizSessionSchema,
   course: ZUuidSchema, // foreign key to Course
   uploader: ZUuidSchema, // foreign key to User
 });
@@ -22,7 +34,7 @@ const quizSchema = new Schema<Quiz, QuizModel>({
     type: String,
     required: true,
     immutable: true,
-    enum: ['midterm', 'final', 'first', 'second', 'other'],
+    enum: QuizSessionEnum,
   },
   course: { type: String, ref: 'Course', required: true, immutable: true },
   uploader: { type: String, ref: 'User', required: true, immutable: true },
@@ -30,4 +42,11 @@ const quizSchema = new Schema<Quiz, QuizModel>({
 
 const QuizModel = model<Quiz, QuizModel>('Quiz', quizSchema);
 
-export { type Quiz, QuizModel, ZQuizSchema };
+export {
+  type Quiz,
+  QuizModel,
+  ZQuizSchema,
+  QuizSession,
+  ZQuizSessionSchema,
+  QuizSessionEnum,
+};

--- a/test/quizzes.test.ts
+++ b/test/quizzes.test.ts
@@ -42,38 +42,7 @@ describe('GET /api/quizzes', () => {
         .get('/api/quizzes')
         .query(qs.stringify({ limit: 5 }))
         .expect(200);
-
-      const body = parseAndExpectValid(ZQuizListResponse, res.body);
-
-      // Verify response structure matches OpenAPI spec
-      expect(body).toHaveProperty('quizzes');
-      expect(body).toHaveProperty('meta');
-      expect(Array.isArray(body.quizzes)).toBe(true);
-
-      // Verify meta structure
-      expect(body.meta).toHaveProperty('total');
-      expect(body.meta).toHaveProperty('limit');
-      expect(body.meta).toHaveProperty('offset');
-      expect(typeof body.meta.total).toBe('number');
-      expect(typeof body.meta.limit).toBe('number');
-      expect(typeof body.meta.offset).toBe('number');
-
-      // Verify quiz structure for each quiz if any exist
-      for (const quiz of body.quizzes) {
-        expect(quiz).toHaveProperty('_id');
-        expect(quiz).toHaveProperty('session');
-        expect(quiz).toHaveProperty('course');
-        expect(quiz).toHaveProperty('uploader');
-
-        // Verify session is one of the allowed enum values
-        expect(['midterm', 'final', 'first', 'second', 'other']).toContain(
-          quiz.session,
-        );
-
-        // Without embedding, course and uploader should be UUIDs (strings)
-        expect(typeof quiz.course).toBe('string');
-        expect(typeof quiz.uploader).toBe('string');
-      }
+      parseAndExpectValid(ZQuizListResponse, res.body);
     });
 
     it('should use default pagination values (limit: 10, offset: 0)', async () => {
@@ -359,10 +328,7 @@ describe('GET /api/quizzes/:quizId', () => {
         .expect(200);
 
       const body = parseAndExpectValid(ZQuizResponse, res.body);
-      expect(body.quiz._id).toBe(testQuiz._id);
-      expect(body.quiz.session).toBe(testQuiz.session);
-      expect(body.quiz.course).toBe(testQuiz.course);
-      expect(body.quiz.uploader).toBe(testQuiz.uploader);
+      expect(body.quiz).toEqual(testQuiz);
     });
 
     it('should support embed parameters correctly', async () => {

--- a/test/response-schemas.ts
+++ b/test/response-schemas.ts
@@ -1,5 +1,6 @@
 import z from 'zod';
 
+import { ZQuizSessionSchema } from '@/models/quiz-schema.ts';
 import { ZUuidSchema } from '@/models/util-schema.ts';
 
 const ZErrorSchema = z.object({
@@ -52,7 +53,7 @@ const ZArticleResponseSchema = z.object({
 
 const ZQuizResponseSchema = z.object({
   _id: ZUuidSchema,
-  session: z.enum(['midterm', 'final', 'first', 'second', 'other']),
+  session: ZQuizSessionSchema,
   course: z.union([ZUuidSchema, ZCourseResponseSchema]),
   uploader: z.union([ZUuidSchema, ZUserResponseSchema]),
 });


### PR DESCRIPTION
Update quiz session schema to utilize an enum for better type safety and clarity. Enhance test response schemas to reflect these changes, ensuring consistency across the application.