### PR TITLE
fix: prioritize .env files under test/

### DIFF
--- a/scripts/fetch-courses.ts
+++ b/scripts/fetch-courses.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import { ZUuidSchema } from '@/models/util-schema.ts';
 import { type Course } from '@models/course-schema.ts';
 
-dotenv.config({ path: ['.env.default', '.env'], override: true });
+dotenv.config({ path: ['.env', '.env.default'] });
 
 if (process.env.SAMPLES_DIR === undefined) {
   console.error('environment variable SAMPLES_DIR is not set');

--- a/scripts/generate-samples.ts
+++ b/scripts/generate-samples.ts
@@ -14,7 +14,7 @@ import {
 } from '@models/quiz-schema.ts';
 import { type User } from '@models/user-schema.ts';
 
-dotenv.config({ path: ['.env.default', '.env'], override: true });
+dotenv.config({ path: ['.env', '.env.default'] });
 
 if (process.env.SAMPLES_DIR === undefined) {
   console.error('environment variable SAMPLES_DIR is not set');

--- a/scripts/setup-dev-db.ts
+++ b/scripts/setup-dev-db.ts
@@ -10,7 +10,7 @@ import { models } from '@models/index.ts';
 import { ZQuizSchema } from '@models/quiz-schema.ts';
 import { ZUserSchema } from '@models/user-schema.ts';
 
-dotenv.config({ path: ['.env.default', '.env'], override: true });
+dotenv.config({ path: ['.env', '.env.default'] });
 
 if (
   process.env.MONGODB_URI === undefined

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 
 import logger from '@utils/logger.ts';
 
-dotenv.config({ path: ['.env.default', '.env'], override: true });
+dotenv.config({ path: ['.env', '.env.default'] });
 
 const EnvSchema = z.object({
   FIREBASE_CERT_PATH: z.string(),

--- a/test/global-setup.ts
+++ b/test/global-setup.ts
@@ -3,16 +3,17 @@ import path from 'path';
 
 import dotenv from 'dotenv';
 
+let originalUploadsDir: string | undefined;
+
 export async function setup() {
   dotenv.config({
-    path: ['.env.default', '.env', 'test/.env.default'],
-    override: true,
+    path: ['test/.env', 'test/.env.default', '.env', '.env.default'],
   });
 
   if (!process.env.UPLOADS_DIR) {
     throw new Error('Missing environment variable: UPLOADS_DIR');
   }
-  process.env.ORIGINAL_UPLOADS_DIR = process.env.UPLOADS_DIR;
+  originalUploadsDir = path.resolve(process.env.UPLOADS_DIR);
 
   const uploadsDir = path.resolve(process.env.UPLOADS_DIR);
   await fs.rm(uploadsDir, { recursive: true, force: true });
@@ -20,9 +21,8 @@ export async function setup() {
 }
 
 export async function teardown() {
-  if (!process.env.ORIGINAL_UPLOADS_DIR) {
+  if (!originalUploadsDir) {
     throw new Error('Missing environment variable: ORIGINAL_UPLOADS_DIR');
   }
-  const originalUploadsDir = path.resolve(process.env.ORIGINAL_UPLOADS_DIR);
   await fs.rm(originalUploadsDir, { recursive: true, force: true });
 }


### PR DESCRIPTION
Load .env files without `override: true` using dotenv to make sure that environment variables injected when test setting up won't be override with those injected in `config.ts`.