### PR TITLE
feat: add rate limiting for API requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "@apidevtools/swagger-parser": "^12.0.0",
         "express": "^5.0.1",
+        "express-rate-limit": "^8.0.1",
         "firebase-admin": "^13.1.0",
         "fuse.js": "^7.1.0",
         "mongoose": "^8.5.2",
@@ -3890,6 +3891,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4868,6 +4887,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^12.0.0",
     "express": "^5.0.1",
+    "express-rate-limit": "^8.0.1",
     "firebase-admin": "^13.1.0",
     "fuse.js": "^7.1.0",
     "mongoose": "^8.5.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import SwaggerParser from '@apidevtools/swagger-parser';
 import express from 'express';
+import { rateLimit } from 'express-rate-limit';
 import { cert, initializeApp } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
 import mongoose from 'mongoose';
@@ -42,6 +43,16 @@ const morganMiddleware = morgan(
 );
 
 expressApp.use(morganMiddleware);
+
+// Limit each IP to 100 requests per minute
+const limiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 100,
+  standardHeaders: 'draft-8',
+  legacyHeaders: false,
+});
+
+expressApp.use(limiter);
 
 expressApp.use(async (req, res, next) => {
   const token = req.headers.authorization;


### PR DESCRIPTION
Add express-rate-limit dependency and configure rate limiting to restrict each IP to 100 requests per minute.