### PR TITLE
chore: disable pnpm side effects cache

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,12 @@
+engineStrict: true
+
+sideEffectsCache: false
+
+onlyBuiltDependencies:
+  - mongodb-memory-server
+
 ignoredBuiltDependencies:
   - '@firebase/util'
   - '@scarf/scarf'
   - esbuild
   - protobufjs
-
-onlyBuiltDependencies:
-  - mongodb-memory-server
-
-engineStrict: true


### PR DESCRIPTION
Disable the side effects cache to ensure the mongodb-memory-server builds correctly.