### PR TITLE
fix: rename FIREBASE_CERT_PATH to GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -3,7 +3,7 @@ MONGODB_DB_NAME='csie-council-dev'
 
 PORT='3010'
 
-FIREBASE_CERT_PATH='./service-account-file.json'
+GOOGLE_APPLICATION_CREDENTIALS='./service-account-file.json'
 
 UPLOADS_DIR='./uploads'
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ import logger from '@utils/logger.ts';
 dotenv.config({ path: ['.env', '.env.default'], quiet: true });
 
 const EnvSchema = z.object({
-  FIREBASE_CERT_PATH: z.string(),
+  GOOGLE_APPLICATION_CREDENTIALS: z.string(),
   MONGODB_URI: z.string(),
   MONGODB_DB_NAME: z.string(),
   PORT: z.string(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import SwaggerParser from '@apidevtools/swagger-parser';
 import express from 'express';
 import { rateLimit } from 'express-rate-limit';
-import { cert, initializeApp } from 'firebase-admin/app';
+import { applicationDefault, initializeApp } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
 import mongoose from 'mongoose';
 import morgan, { type StreamOptions } from 'morgan';
@@ -15,9 +15,7 @@ import { env } from './config.ts';
 
 let auth;
 try {
-  const firebaseApp = initializeApp({
-    credential: cert(env.FIREBASE_CERT_PATH),
-  });
+  const firebaseApp = initializeApp({ credential: applicationDefault() });
   logger.info('Connected to Firebase');
   auth = getAuth(firebaseApp);
   logger.info('Initialized Firebase Auth');


### PR DESCRIPTION
Rename  FIREBASE_CERT_PATH to GOOGLE_APPLICATION_CREDENTIALS for alignment of suggestions in [official documents](https://firebase.google.com/docs/admin/setup#initialize_the_sdk_in_non-google_environments).