### PR TITLE
feat: add timestamp to article schema

### DIFF
--- a/openapi/components/schemas.yaml
+++ b/openapi/components/schemas.yaml
@@ -122,7 +122,15 @@ ArticleResponse:
             Article content preview (first 50 characters). Returns empty string 
             if no content file has been uploaded. Use the file endpoint to retrieve full content.
           example: 'This is a sample article content that is very...'
-  required: [_id, title, tags, ratings, course, creator]
+        createdAt:
+          type: string
+          description: Article created time (ISO 8601)
+          example: '2025-10-29T16:37:48.244Z'
+        updatedAt:
+          type: string
+          description: Article last updated time (ISO 8601)
+          example: '2025-10-30T16:37:48.244Z'
+  required: [_id, title, tags, ratings, course, creator, createdAt, updatedAt]
 
 CourseResponse:
   type: object

--- a/scripts/generate-samples.ts
+++ b/scripts/generate-samples.ts
@@ -120,6 +120,8 @@ function generateArticles(
       title: course.names[0],
       tags: [lecturer, course.names[0], dep],
       ratings,
+      updatedAt: new Date(),
+      createdAt: new Date(),
     };
     articles.push(article);
   }

--- a/src/models/article-schema.ts
+++ b/src/models/article-schema.ts
@@ -4,6 +4,7 @@ import Fuse from 'fuse.js';
 import {
   model,
   Schema,
+  type Date,
   type FilterQuery,
   type HydratedDocument,
   type Model,
@@ -29,13 +30,18 @@ const ZArticleSchema = z.object({
   ratings: ZRatingSchema,
   course: ZUuidSchema, // foreign key to Course
   creator: ZUuidSchema, // foreign key to User
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
 });
 
 interface Article extends z.infer<typeof ZArticleSchema> {}
 
-interface PopulatedArticle extends Omit<Article, 'course' | 'creator'> {
+interface PopulatedArticle
+  extends Omit<Article, 'course' | 'creator' | 'createdAt' | 'updatedAt'> {
   course: Course;
   creator: User;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 interface ArticleModel extends Model<Article> {
@@ -112,7 +118,7 @@ const articleSchema = new Schema<Article, ArticleModel>(
     course: { type: String, ref: 'Course', required: true, immutable: true },
     creator: { type: String, ref: 'User', required: true, immutable: true },
   },
-  { toObject: { versionKey: false } },
+  { toObject: { versionKey: false }, timestamps: true },
 );
 
 const staticSearchArticles: ArticleModel['searchArticles'] = async function (
@@ -127,6 +133,8 @@ const staticSearchArticles: ArticleModel['searchArticles'] = async function (
   let articles = await this.find(query).populate<{
     course: Course;
     creator: User;
+    createdAt: Date;
+    updatedAt: Date;
   }>(['course', 'creator']);
 
   if (params.keyword) {

--- a/src/routers/article-controller.ts
+++ b/src/routers/article-controller.ts
@@ -99,11 +99,17 @@ router.post('/', async (req, res) => {
     return;
   }
 
-  let articleCreate: Omit<Article, '_id' | 'creator'>;
+  let articleCreate: Omit<
+    Article,
+    '_id' | 'creator' | 'createdAt' | 'updatedAt'
+  >;
   try {
-    articleCreate = ZArticleSchema.omit({ _id: true, creator: true }).parse(
-      req.body,
-    );
+    articleCreate = ZArticleSchema.omit({
+      _id: true,
+      creator: true,
+      createdAt: true,
+      updatedAt: true,
+    }).parse(req.body);
   } catch (err) {
     logger.warn('Failed to parse request body in POST /articles: ', err);
     res.status(400).json({ message: 'Invalid request body' });
@@ -187,6 +193,8 @@ router.patch('/:articleId', async (req, res) => {
       _id: true,
       course: true,
       creator: true,
+      createdAt: true,
+      updatedAt: true,
     })
       .extend({ ratings: ZRatingSchema.partial() })
       .partial()
@@ -287,7 +295,7 @@ router.put('/:articleId/file', async (req, res) => {
     return;
   }
 
-  const article = await ArticleModel.findById(articleId).lean().exec();
+  const article = await ArticleModel.findById(articleId).exec();
   if (article === null) {
     res.status(404).json({ message: 'Article not found' });
     return;
@@ -311,6 +319,7 @@ router.put('/:articleId/file', async (req, res) => {
     res.status(500).json({ message: 'Failed to write article file' });
     return;
   }
+  await article.updateOne({ updatedAt: true });
   res.sendStatus(204);
 });
 

--- a/test/articles.test.ts
+++ b/test/articles.test.ts
@@ -469,11 +469,16 @@ describe('POST /api/articles', () => {
           .get(`/api/articles/${body.articleId}`)
           .expect(200);
         const getBody = parseAndExpectValid(ZArticleResponse, res.body);
-        expect(getBody.article).toEqual({
+        expect(getBody.article).toMatchObject({
           ...articleData,
           _id: body.articleId,
           creator: creator._id,
         });
+        const createdAt = new Date(getBody.article.createdAt);
+        const updatedAt = new Date(getBody.article.updatedAt);
+        expect(updatedAt.getTime()).toBe(createdAt.getTime());
+        expect(() => createdAt.toISOString()).not.toThrow();
+        expect(() => updatedAt.toISOString()).not.toThrow();
       }
     });
 
@@ -929,6 +934,47 @@ describe('PATCH /api/articles/:articleId', () => {
       }
     });
 
+    it('should update updatedAt timestamp', async () => {
+      const article = await getTestArticle();
+      const creator = await UserModel.findById(article.creator)
+        .lean({ versionKey: false })
+        .exec();
+
+      const initialRes = await request(app)
+        .get(`/api/articles/${article._id}`)
+        .expect(200);
+
+      const initialBody = parseAndExpectValid(
+        ZArticleResponse,
+        initialRes.body,
+      );
+      const initialTimestamp = new Date(
+        initialBody.article.updatedAt,
+      ).getTime();
+
+      const updates = {
+        title: 'Multi Update Test',
+        tags: ['multi', 'update'],
+        ratings: { sweetness: 5, chill: 4, teaching: 3, gain: 2, recommend: 1 },
+      };
+
+      await request(app)
+        .patch(`/api/articles/${article._id}`)
+        .send(updates)
+        .set('gid', creator!.gid)
+        .expect(204);
+
+      {
+        const res = await request(app)
+          .get(`/api/articles/${article._id}`)
+          .expect(200);
+        const body = parseAndExpectValid(ZArticleResponse, res.body);
+        expect(new Date(body.article.updatedAt).getTime()).toBeGreaterThan(
+          initialTimestamp,
+        );
+      }
+    });
+
     it('should handle empty updates', async () => {
       const article = await getTestArticle();
       const creator = await UserModel.findById(article.creator)
@@ -1148,7 +1194,7 @@ describe('GET /api/articles/:articleId/file', () => {
 
 describe('PUT /api/articles/:articleId/file', () => {
   describe('Successful file operations', () => {
-    it('should upload and update file content', async () => {
+    it('should upload and update file content and timestamp', async () => {
       const creator = await getTestUser();
 
       let articleId: string;
@@ -1162,6 +1208,18 @@ describe('PUT /api/articles/:articleId/file', () => {
         articleId = body.articleId;
       }
 
+      const initialRes = await request(app)
+        .get(`/api/articles/${articleId}`)
+        .expect(200);
+
+      const initialBody = parseAndExpectValid(
+        ZArticleResponse,
+        initialRes.body,
+      );
+      const initialTimestamp = new Date(
+        initialBody.article.updatedAt,
+      ).getTime();
+
       // Upload content
       const initialContent =
         '# Initial Content\n\nThis is the initial content.';
@@ -1171,13 +1229,27 @@ describe('PUT /api/articles/:articleId/file', () => {
         .set('gid', creator.gid)
         .expect(204);
 
+      // sleep for 1 second to ensure timestamp difference
+      await new Promise(resolve => setTimeout(resolve, 1000));
+
       // Verify content
       {
-        const res = await request(app)
+        const fileRes = await request(app)
           .get(`/api/articles/${articleId}/file`)
           .expect(200);
-        const body = parseAndExpectValid(ZFileResponse, res.body);
+        const body = parseAndExpectValid(ZFileResponse, fileRes.body);
         expect(body.file).toBe(initialContent);
+
+        const articleRes = await request(app)
+          .get(`/api/articles/${articleId}`)
+          .expect(200);
+        const articleBody = parseAndExpectValid(
+          ZArticleResponse,
+          articleRes.body,
+        );
+        expect(
+          new Date(articleBody.article.updatedAt).getTime(),
+        ).toBeGreaterThan(initialTimestamp);
       }
 
       // Update content

--- a/test/response-schemas.ts
+++ b/test/response-schemas.ts
@@ -49,6 +49,8 @@ const ZArticleResponseSchema = z.object({
   course: z.union([ZUuidSchema, ZCourseResponseSchema]),
   creator: z.union([ZUuidSchema, ZUserResponseSchema]),
   content: z.string().optional(),
+  createdAt: z.iso.datetime(),
+  updatedAt: z.iso.datetime(),
 });
 
 const ZQuizResponseSchema = z.object({


### PR DESCRIPTION
Add `createdAt` and `updatedAt` timestamp to article schema. Both timestamp are set when first the article is created, `updatedAt` timestamp is updated when `PATCH articles/{articleId}` or `PUT articles/{articleId}/file`