### PR TITLE
chore: update mongoose to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "express-rate-limit": "^8.5.2",
     "firebase-admin": "^14.1.0",
     "fuse.js": "^7.4.2",
-    "mongoose": "^8.24.1",
+    "mongoose": "^9.7.3",
     "morgan": "^1.11.0",
     "swagger-ui-express": "^5.0.1",
     "winston": "^3.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^7.4.2
         version: 7.4.2
       mongoose:
-        specifier: ^8.24.1
-        version: 8.24.1
+        specifier: ^9.7.3
+        version: 9.7.3
       morgan:
         specifier: ^1.11.0
         version: 1.11.0
@@ -821,9 +821,6 @@ packages:
   '@types/webidl-conversions@7.0.3':
     resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
 
-  '@types/whatwg-url@11.0.5':
-    resolution: {integrity: sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==}
-
   '@types/whatwg-url@13.0.0':
     resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
 
@@ -1103,10 +1100,6 @@ packages:
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
-
-  bson@6.10.4:
-    resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
-    engines: {node: '>=16.20.1'}
 
   bson@7.3.1:
     resolution: {integrity: sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==}
@@ -1845,9 +1838,9 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
-  kareem@2.6.3:
-    resolution: {integrity: sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==}
-    engines: {node: '>=12.0.0'}
+  kareem@3.3.0:
+    resolution: {integrity: sha512-kpSuLD3/7RenBnjnJdOHXCKC8dTd1JzeOiJhN0necWWci6cC+qX+VuwPnMVgb+a4+KNJSfgqahpnfWaeDXCimw==}
+    engines: {node: '>=18.0.0'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2076,9 +2069,6 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  mongodb-connection-string-url@3.0.2:
-    resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
-
   mongodb-connection-string-url@7.0.1:
     resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
     engines: {node: '>=20.19.0'}
@@ -2091,17 +2081,17 @@ packages:
     resolution: {integrity: sha512-506AD8qvClVx8Raw/WhAUUWBgIXPyi856iC01aa5vAzHmn6WOXC6ulvudkTF7oTMzJxkyA0A84VpD4BpyfqJ9w==}
     engines: {node: '>=20.19.0'}
 
-  mongodb@6.20.0:
-    resolution: {integrity: sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==}
-    engines: {node: '>=16.20.1'}
+  mongodb@7.2.0:
+    resolution: {integrity: sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw==}
+    engines: {node: '>=20.19.0'}
     peerDependencies:
-      '@aws-sdk/credential-providers': ^3.188.0
-      '@mongodb-js/zstd': ^1.1.0 || ^2.0.0
-      gcp-metadata: ^5.2.0
-      kerberos: ^2.0.1
-      mongodb-client-encryption: '>=6.0.0 <7'
+      '@aws-sdk/credential-providers': ^3.806.0
+      '@mongodb-js/zstd': ^7.0.0
+      gcp-metadata: ^7.0.1
+      kerberos: ^7.0.0
+      mongodb-client-encryption: '>=7.0.0 <7.1.0'
       snappy: ^7.3.2
-      socks: ^2.7.1
+      socks: ^2.8.6
     peerDependenciesMeta:
       '@aws-sdk/credential-providers':
         optional: true
@@ -2145,9 +2135,9 @@ packages:
       socks:
         optional: true
 
-  mongoose@8.24.1:
-    resolution: {integrity: sha512-UpHBA0l5kHyKJQFjmBaFYQFo5sgz1DK0TRqDkOyBLYbqiIbKKhIvBpHWBXqeo0rgW4kGI1UhhAw+kTQZoj1BdA==}
-    engines: {node: '>=16.20.1'}
+  mongoose@9.7.3:
+    resolution: {integrity: sha512-9DsD4sq0tL9IKyfttZ6qn74KXBcD4lxDTzGXoAeOLMnDFFp1gqc5oc4s2BiMPbetJrLwvVylfyR4cqLst2pasQ==}
+    engines: {node: '>=20.19.0'}
 
   morgan@1.11.0:
     resolution: {integrity: sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==}
@@ -2157,9 +2147,9 @@ packages:
     resolution: {integrity: sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==}
     engines: {node: '>=4.0.0'}
 
-  mquery@5.0.0:
-    resolution: {integrity: sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==}
-    engines: {node: '>=14.0.0'}
+  mquery@6.0.0:
+    resolution: {integrity: sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==}
+    engines: {node: '>=20.19.0'}
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -3572,10 +3562,6 @@ snapshots:
 
   '@types/webidl-conversions@7.0.3': {}
 
-  '@types/whatwg-url@11.0.5':
-    dependencies:
-      '@types/webidl-conversions': 7.0.3
-
   '@types/whatwg-url@13.0.0':
     dependencies:
       '@types/webidl-conversions': 7.0.3
@@ -3896,8 +3882,6 @@ snapshots:
   brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
-
-  bson@6.10.4: {}
 
   bson@7.3.1: {}
 
@@ -4769,7 +4753,7 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
-  kareem@2.6.3: {}
+  kareem@3.3.0: {}
 
   keyv@4.5.4:
     dependencies:
@@ -4966,11 +4950,6 @@ snapshots:
   minipass@7.1.3:
     optional: true
 
-  mongodb-connection-string-url@3.0.2:
-    dependencies:
-      '@types/whatwg-url': 11.0.5
-      whatwg-url: 14.2.0
-
   mongodb-connection-string-url@7.0.1:
     dependencies:
       '@types/whatwg-url': 13.0.0
@@ -5020,11 +4999,11 @@ snapshots:
       - socks
       - supports-color
 
-  mongodb@6.20.0:
+  mongodb@7.2.0:
     dependencies:
       '@mongodb-js/saslprep': 1.4.12
-      bson: 6.10.4
-      mongodb-connection-string-url: 3.0.2
+      bson: 7.3.1
+      mongodb-connection-string-url: 7.0.1
 
   mongodb@7.4.0:
     dependencies:
@@ -5032,13 +5011,13 @@ snapshots:
       bson: 7.3.1
       mongodb-connection-string-url: 7.0.1
 
-  mongoose@8.24.1:
+  mongoose@9.7.3:
     dependencies:
-      bson: 6.10.4
-      kareem: 2.6.3
-      mongodb: 6.20.0
+      '@standard-schema/spec': 1.1.0
+      kareem: 3.3.0
+      mongodb: 7.2.0
       mpath: 0.9.0
-      mquery: 5.0.0
+      mquery: 6.0.0
       ms: 2.1.3
       sift: 17.1.3
     transitivePeerDependencies:
@@ -5049,7 +5028,6 @@ snapshots:
       - mongodb-client-encryption
       - snappy
       - socks
-      - supports-color
 
   morgan@1.11.0:
     dependencies:
@@ -5063,11 +5041,7 @@ snapshots:
 
   mpath@0.9.0: {}
 
-  mquery@5.0.0:
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
+  mquery@6.0.0: {}
 
   ms@2.0.0: {}
 

--- a/src/models/article-schema.ts
+++ b/src/models/article-schema.ts
@@ -5,9 +5,9 @@ import {
   model,
   Schema,
   type Date,
-  type FilterQuery,
   type HydratedDocument,
   type Model,
+  type QueryFilter,
 } from 'mongoose';
 import { z } from 'zod';
 
@@ -60,7 +60,7 @@ interface ArticleModel extends Model<Article> {
 
 const articleSchema = new Schema<Article, ArticleModel>(
   {
-    _id: { type: String, default: randomUUID },
+    _id: { type: String, default: () => randomUUID() },
     title: { type: String, required: true, maxLength: 40 },
     tags: {
       type: [String],
@@ -126,18 +126,21 @@ const articleSchema = new Schema<Article, ArticleModel>(
 const staticSearchArticles: ArticleModel['searchArticles'] = async function (
   params,
 ) {
-  const query: FilterQuery<Article> = {};
+  const query: QueryFilter<Article> = {};
 
   if (params.tags) {
     query.tags = { $all: params.tags };
   }
 
-  let articles = await this.find(query).populate<{
+  // `populate` widens `course`/`creator` to their referenced documents, but its
+  // inferred type doesn't structurally unify with `HydratedDocument<PopulatedArticle>`,
+  // so we cast to the intended populated document type.
+  let articles = (await this.find(query).populate<{
     course: Course;
     creator: User;
     createdAt: Date;
     updatedAt: Date;
-  }>(['course', 'creator']);
+  }>(['course', 'creator'])) as unknown as HydratedDocument<PopulatedArticle>[];
 
   if (params.keyword) {
     const fuseOptions = {

--- a/src/models/course-schema.ts
+++ b/src/models/course-schema.ts
@@ -27,7 +27,7 @@ interface CourseModel extends Model<Course> {
 
 const courseSchema = new Schema<Course, CourseModel>(
   {
-    _id: { type: String, default: randomUUID },
+    _id: { type: String, default: () => randomUUID() },
     curriculum: { type: String, required: true },
     lecturer: { type: String, required: true },
     class: { type: String },

--- a/src/models/quiz-schema.ts
+++ b/src/models/quiz-schema.ts
@@ -29,7 +29,7 @@ interface Quiz extends z.infer<typeof ZQuizSchema> {}
 interface QuizModel extends Model<Quiz> {}
 
 const quizSchema = new Schema<Quiz, QuizModel>({
-  _id: { type: String, default: randomUUID },
+  _id: { type: String, default: () => randomUUID() },
   session: {
     type: String,
     required: true,

--- a/src/models/user-schema.ts
+++ b/src/models/user-schema.ts
@@ -18,7 +18,7 @@ interface User extends z.infer<typeof ZUserSchema> {}
 interface UserModel extends Model<User> {}
 
 const userSchema = new Schema<User, UserModel>({
-  _id: { type: String, default: randomUUID },
+  _id: { type: String, default: () => randomUUID() },
   gid: { type: String, required: true, unique: true },
   email: { type: String, required: true, unique: true },
   name: { type: String, required: true },

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -68,7 +68,7 @@ const getTestDoc = async <T>(model: mongoose.Model<T>): Promise<T> => {
     .lean({ versionKey: false })
     .exec();
   if (!doc) throw new Error(`No test ${model.modelName.toLowerCase()} found`);
-  return doc as T;
+  return doc;
 };
 
 const getTestArticle = async (): Promise<Article> => {


### PR DESCRIPTION
## Summary

Updates **mongoose** from `8.24.1` → `9.7.3` via pnpm — the last dependency held back on `chore/update-deps` (see `b6941b6 chore: update all deps despite mongoose`). Base is `chore/update-deps` so the diff stays focused on the mongoose change.

`9.7.3` (not `9.7.4`) is what pnpm installed: the repo's `minimumReleaseAge` supply-chain policy holds back very recently published versions. The `^9.7.3` range will pick up `9.7.4` automatically once it ages past the threshold. This respects the existing policy rather than forcing an exclusion.

## Mongoose 9 TypeScript changes

Mongoose 9 tightened its TypeScript types. Clean fixes:

- **`FilterQuery` → `QueryFilter`** — `FilterQuery` was renamed and its old name is no longer exported (`article-schema.ts`).
- **`_id` defaults** — `default: randomUUID` → `default: () => randomUUID()` in all four schemas. v9's `default` signature is now typed `(this, doc) => …`, and `randomUUID`'s `(options?) => UUID` signature fails the stricter (contravariant) param check. Wrapping it in a zero-arg arrow resolves it cleanly.
- **`searchArticles` populate result** — cast to `HydratedDocument<PopulatedArticle>[]`. `.populate<Override>()`'s inferred `MergeType` shape no longer structurally unifies with the named populated type (it keeps `Article`-typed query helpers). This mismatch already errored on the branch before the bump; the cast (mongoose's own recommended escape hatch here) makes intent explicit, with a comment.
- **`test/utils.ts`** — dropped a now-unnecessary `as T` on a `.lean().exec()` result; v9's more precise lean return type makes the assertion redundant (eslint flagged it).

## Verification

- `pnpm type-check` — passes (exit 0)
- `pnpm lint:check` — passes (exit 0)
- `pnpm format:check` — clean
- `pnpm test` — **144/144 pass**

> Note: running the suite *inside* a `.claude/worktrees/…` path makes 2 quiz-file tests 500, because express 5's `res.sendFile` (`send`'s default `dotfiles: 'ignore'`) rejects any path containing a dot-segment like `.claude`. Reproduced standalone with zero mongoose involvement; does not occur in a normal checkout. Pointing `UPLOADS_DIR` at a non-dotfile path yields a clean 144/144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011V2B4cR96Hvjytpyc4eLdF