### PR TITLE
fix(docker): copy package.json before pnpm fetch to pin pnpm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,9 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-COPY pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 RUN pnpm fetch
 
-COPY package.json ./
 COPY .husky/install.mjs .husky/install.mjs
 RUN pnpm install --offline --frozen-lockfile
 


### PR DESCRIPTION
`pnpm fetch` ran before package.json was copied, so corepack could not read the `packageManager` pin and fell back to the latest pnpm (11.10.0), while `pnpm install` used the pinned 10.17.1. pnpm then tried to remove `node_modules` created by the newer version and aborted.

Copy package.json alongside the lockfile before `pnpm fetch` so both steps resolve the same pinned pnpm version.