### PR TITLE
fix: restrict embedded creator/uploader to public user fields

### DIFF
--- a/src/models/article-schema.ts
+++ b/src/models/article-schema.ts
@@ -140,7 +140,10 @@ const staticSearchArticles: ArticleModel['searchArticles'] = async function (
     creator: User;
     createdAt: Date;
     updatedAt: Date;
-  }>(['course', 'creator'])) as unknown as HydratedDocument<PopulatedArticle>[];
+  }>([
+    { path: 'course' },
+    { path: 'creator', select: '_id nickname' },
+  ])) as unknown as HydratedDocument<PopulatedArticle>[];
 
   if (params.keyword) {
     const fuseOptions = {

--- a/src/routers/article-controller.ts
+++ b/src/routers/article-controller.ts
@@ -156,7 +156,7 @@ router.get('/:articleId', async (req, res) => {
     query = query.populate('course');
   }
   if (embedParam.embed?.includes('creator')) {
-    query = query.populate('creator');
+    query = query.populate('creator', '_id nickname');
   }
   const article = await query.lean({ versionKey: false }).exec();
   if (article === null) {

--- a/src/routers/course-controller.ts
+++ b/src/routers/course-controller.ts
@@ -98,7 +98,7 @@ router.get(
       query = query.populate('course');
     }
     if (embedParam.embed?.includes('uploader')) {
-      query = query.populate('uploader');
+      query = query.populate('uploader', '_id nickname');
     }
 
     const quizzes = await query.lean({ versionKey: false }).exec();

--- a/src/routers/quiz-controller.ts
+++ b/src/routers/quiz-controller.ts
@@ -38,7 +38,7 @@ router.get('/', paginationParser, async (req, res) => {
     query = query.populate('course');
   }
   if (embedParam.embed?.includes('uploader')) {
-    query = query.populate('uploader');
+    query = query.populate('uploader', '_id nickname');
   }
 
   const quizzes = await query.lean({ versionKey: false }).exec();
@@ -63,7 +63,7 @@ router.get('/:quizId', async (req, res) => {
     query = query.populate('course');
   }
   if (embedParam.embed?.includes('uploader')) {
-    query = query.populate('uploader');
+    query = query.populate('uploader', '_id nickname');
   }
 
   const quiz = await query.lean({ versionKey: false }).exec();

--- a/test/articles.test.ts
+++ b/test/articles.test.ts
@@ -17,6 +17,7 @@ import {
   ZMetaSchema,
 } from './response-schemas.ts';
 import {
+  expectPublicUserOnly,
   expectValidErrorResponse,
   getTestArticle,
   getTestCourse,
@@ -369,6 +370,21 @@ describe('GET /api/articles', () => {
           }
         }
       }
+    });
+
+    it('should not leak private user fields in embedded creator', async () => {
+      const res = await request(app)
+        .get('/api/articles')
+        .query(qs.stringify({ embed: ['creator'], limit: 100 }))
+        .expect(200);
+
+      // Inspect the raw body: Zod parsing would strip the leaked keys.
+      const { articles } = res.body as { articles: { creator: unknown }[] };
+      const embeddedCreators = articles
+        .map(article => article.creator)
+        .filter(creator => typeof creator === 'object' && creator !== null);
+      expect(embeddedCreators.length).toBeGreaterThan(0);
+      for (const creator of embeddedCreators) expectPublicUserOnly(creator);
     });
 
     it('should validate embed parameters', async () => {
@@ -759,6 +775,19 @@ describe('GET /api/articles/:articleId', () => {
           expect(body.article).toHaveProperty('content');
         }
       }
+    });
+
+    it('should not leak private user fields in embedded creator', async () => {
+      const article = await getTestArticle();
+
+      const res = await request(app)
+        .get(`/api/articles/${article._id}`)
+        .query(qs.stringify({ embed: ['creator'] }))
+        .expect(200);
+
+      // Inspect the raw body: Zod parsing would strip the leaked keys.
+      const body = res.body as { article: { creator: unknown } };
+      expectPublicUserOnly(body.article.creator);
     });
 
     it('should handle content embedding with truncation', async () => {

--- a/test/quizzes.test.ts
+++ b/test/quizzes.test.ts
@@ -11,6 +11,7 @@ import app from './app.ts';
 import { ZMetaSchema, ZQuizResponseSchema } from './response-schemas.ts';
 import {
   authedRequest,
+  expectPublicUserOnly,
   expectValidErrorResponse,
   getTestCourse,
   getTestQuiz,
@@ -209,6 +210,20 @@ describe('GET /api/quizzes', () => {
         expect(quiz.uploader).toBeTypeOf('string');
       }
     });
+
+    it('should not leak private user fields in embedded uploader', async () => {
+      const res = await authedRequest('/api/quizzes')
+        .query(qs.stringify({ embed: ['uploader'], limit: 100 }))
+        .expect(200);
+
+      // Inspect the raw body: Zod parsing would strip the leaked keys.
+      const { quizzes } = res.body as { quizzes: { uploader: unknown }[] };
+      const embeddedUploaders = quizzes
+        .map(quiz => quiz.uploader)
+        .filter(uploader => typeof uploader === 'object' && uploader !== null);
+      expect(embeddedUploaders.length).toBeGreaterThan(0);
+      for (const uploader of embeddedUploaders) expectPublicUserOnly(uploader);
+    });
   });
 });
 
@@ -272,6 +287,18 @@ describe('GET /api/quizzes/:quizId', () => {
         expect(body.quiz.uploader).toBeTypeOf('object');
       }
     });
+
+    it('should not leak private user fields in embedded uploader', async () => {
+      const testQuiz = await getTestQuiz();
+
+      const res = await authedRequest(`/api/quizzes/${testQuiz._id}`)
+        .query(qs.stringify({ embed: ['uploader'] }))
+        .expect(200);
+
+      // Inspect the raw body: Zod parsing would strip the leaked keys.
+      const body = res.body as { quiz: { uploader: unknown } };
+      expectPublicUserOnly(body.quiz.uploader);
+    });
   });
 
   describe('Parameter validation', () => {
@@ -332,5 +359,24 @@ describe('GET /api/quizzes/:quizId/file', () => {
       ).expect(404);
       expectValidErrorResponse(res.body);
     });
+  });
+});
+
+describe('GET /api/courses/:courseId/quizzes', () => {
+  it('should not leak private user fields in embedded uploader', async () => {
+    // A course guaranteed to have at least one quiz.
+    const quiz = await getTestQuiz();
+
+    const res = await authedRequest(`/api/courses/${quiz.course}/quizzes`)
+      .query(qs.stringify({ embed: ['uploader'], limit: 100 }))
+      .expect(200);
+
+    // Inspect the raw body: Zod parsing would strip the leaked keys.
+    const { quizzes } = res.body as { quizzes: { uploader: unknown }[] };
+    const embeddedUploaders = quizzes
+      .map(q => q.uploader)
+      .filter(uploader => typeof uploader === 'object' && uploader !== null);
+    expect(embeddedUploaders.length).toBeGreaterThan(0);
+    for (const uploader of embeddedUploaders) expectPublicUserOnly(uploader);
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -49,6 +49,16 @@ const expectValidErrorResponse = (body: unknown) => {
   expect(z.strictObject(ZErrorSchema.shape).safeParse(body).success).toBe(true);
 };
 
+// Asserts an embedded user (?embed=creator/uploader) exposes only the public UserResponse fields, never the private gid/email/name.
+const expectPublicUserOnly = (user: unknown) => {
+  expect(user).toBeTypeOf('object');
+  expect(user).not.toBeNull();
+  expect(Object.keys(user as Record<string, unknown>).sort()).toEqual([
+    '_id',
+    'nickname',
+  ]);
+};
+
 const parseAndExpectValid = <T extends z.ZodRawShape>(
   schema: z.ZodObject<T>,
   body: unknown,
@@ -92,6 +102,7 @@ const authedRequest = (path: string) =>
 
 export {
   expectValidErrorResponse,
+  expectPublicUserOnly,
   parseAndExpectValid,
   seedModelFromSamples,
   getTestArticle,


### PR DESCRIPTION
`?embed=creator` (articles) and `?embed=uploader` (quizzes) populated the full User document, leaking every user's gid, email, and real name.

Project only the public user fields (`_id nickname`) when populating these refs. This covers `GET /articles`, `GET /articles/:id`, `GET /quizzes`, `GET /quizzes/:id`, and `GET /courses/:id/quizzes`, matching the OpenAPI spec and `GET /users/:id`.