### PR TITLE
fix(articles): validate course ID against Course collection

### DIFF
--- a/src/routers/article-controller.ts
+++ b/src/routers/article-controller.ts
@@ -14,6 +14,7 @@ import {
   type Article,
   type PopulatedArticle,
 } from '@models/article-schema.ts';
+import { CourseModel } from '@models/course-schema.ts';
 import {
   ZArticleEmbedQueryParam,
   ZArticleSearchQueryParam,
@@ -116,9 +117,7 @@ router.post('/', async (req, res) => {
     return;
   }
 
-  const courseExists = await ArticleModel.exists({
-    course: articleCreate.course,
-  });
+  const courseExists = await CourseModel.exists({ _id: articleCreate.course });
   if (!courseExists) {
     logger.warn(
       `Course not found for article creation: ${articleCreate.course}`,

--- a/test/articles.test.ts
+++ b/test/articles.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
 import { ArticleModel } from '@models/article-schema.ts';
+import { CourseModel } from '@models/course-schema.ts';
 import { UserModel } from '@models/user-schema.ts';
 import { ZUuidSchema } from '@models/util-schema.ts';
 import app from './app.ts';
@@ -486,6 +487,31 @@ describe('POST /api/articles', () => {
         expect(() => createdAt.toISOString()).not.toThrow();
         expect(() => updatedAt.toISOString()).not.toThrow();
       }
+    });
+
+    it('should create an article for a course that has no articles yet', async () => {
+      const creator = await getTestUser();
+      // Fresh course with zero articles — mirrors a brand-new production DB.
+      const course = await CourseModel.create({
+        curriculum: 'CSIE9999',
+        lecturer: 'Untouched Lecturer',
+        names: ['Course With No Articles'],
+        credit: 3,
+        semester: '113-2',
+      });
+
+      const res = await request(app)
+        .post('/api/articles')
+        .send({
+          title: 'First review of this course',
+          tags: ['test'],
+          ratings: createTestRatings(),
+          course: course._id,
+        })
+        .set('gid', creator.gid)
+        .expect(201);
+
+      parseAndExpectValid(ZArticleCreateResponse, res.body);
     });
 
     it('should set authenticated user as creator', async () => {


### PR DESCRIPTION
POST /articles checked course existence with ArticleModel.exists({ course }), which only passes if another article already references that course. On a fresh database (zero articles) every creation returned 400 Invalid course ID, and it never actually verified the course exists. Query the Course collection by _id instead.