### PR TITLE
perf(auth): drop per-request Firebase getUser call

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,9 +67,6 @@ expressApp.use(async (req, res, next) => {
 
   if (rawToken !== undefined) {
     try {
-      // verifyIdToken is a local JWT check (signing certs are cached); the
-      // decoded token carries uid/email/email_verified, so no getUser round-trip
-      // to Firebase is needed on the request path — see POST /users for signup.
       const decodedToken = await auth.verifyIdToken(rawToken);
       req.decodedToken = decodedToken;
       req.rawToken = rawToken;

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,6 @@ const limiter = rateLimit({
 expressApp.use(limiter);
 
 expressApp.use(async (req, res, next) => {
-  console.log(`Incoming request: ${req.method} ${req.url}`);
   const authHeader = req.headers.authorization;
   const cookieToken = (req.cookies as Record<string, string | undefined>).token;
   const rawToken = authHeader?.startsWith('Bearer ')
@@ -68,15 +67,18 @@ expressApp.use(async (req, res, next) => {
 
   if (rawToken !== undefined) {
     try {
+      // verifyIdToken is a local JWT check (signing certs are cached); the
+      // decoded token carries uid/email/email_verified, so no getUser round-trip
+      // to Firebase is needed on the request path — see POST /users for signup.
       const decodedToken = await auth.verifyIdToken(rawToken);
-      const userRecord = await auth.getUser(decodedToken.uid);
-      req.guser = userRecord;
+      req.decodedToken = decodedToken;
       req.rawToken = rawToken;
-      const userId = (await UserModel.findOne({ gid: decodedToken.uid }).exec())
-        ?._id;
-      req.userId = userId;
-      console.log(`Authenticated user: ${userRecord.uid}`);
-      // okay
+      req.userId = (
+        await UserModel.findOne({ gid: decodedToken.uid })
+          .select('_id')
+          .lean()
+          .exec()
+      )?._id;
     } catch (err) {
       logger.error('Error verifying Firebase token: ', err);
     }

--- a/src/routers/middleware.ts
+++ b/src/routers/middleware.ts
@@ -5,8 +5,9 @@ import logger from '@/utils/logger.ts';
 import { ZPaginationQueryParam } from '@models/util-schema.ts';
 
 const requireCsie: RequestHandler = (req, res, next) => {
-  const email = req.guser?.email ?? '';
-  if (!email.endsWith('@csie.ntu.edu.tw')) {
+  const email = req.decodedToken?.email ?? '';
+  const emailVerified = req.decodedToken?.email_verified ?? false;
+  if (!emailVerified || !email.endsWith('@csie.ntu.edu.tw')) {
     logger.warn(
       `Access denied for non-csie user: ${email || 'unauthenticated'}`,
     );

--- a/src/routers/user-controller.ts
+++ b/src/routers/user-controller.ts
@@ -30,11 +30,12 @@ router.all('/me{/*splat}', (req, res, next) => {
 });
 
 router.post('/', async (req, res) => {
-  if (req.guser === undefined) {
+  if (req.decodedToken === undefined) {
     logger.warn('Unauthorized access to POST /users');
     res.status(401).json({ message: 'Unauthorized' });
     return;
   }
+  const { uid: gid } = req.decodedToken;
 
   let userCreate;
   try {
@@ -45,26 +46,28 @@ router.post('/', async (req, res) => {
     return;
   }
 
-  const existingUser = await UserModel.findOne({ gid: req.guser.uid }).exec();
+  const existingUser = await UserModel.findOne({ gid }).exec();
   if (existingUser) {
-    logger.warn(`User already exists with gid ${req.guser.uid}`);
+    logger.warn(`User already exists with gid ${gid}`);
     res.status(409).json({ message: 'User already exists' });
     return;
   }
 
-  if (req.guser.displayName === undefined || req.guser.email === undefined) {
-    logger.warn(`Missing user information for gid ${req.guser.uid}`);
-    logger.warn('User information:', req.guser);
+  // The signup profile comes from the just-minted ID token's claims (Google
+  // sign-in populates `name`/`email`), so no getUser round-trip is needed. The
+  // `name` claim lives on DecodedIdToken's index signature, so pull it out via
+  // Zod to keep it typed rather than reaching through `any`.
+  const { name, email } = z
+    .object({ name: z.string(), email: z.string() })
+    .partial()
+    .parse(req.decodedToken);
+  if (name === undefined || email === undefined) {
+    logger.warn(`Missing user information for gid ${gid}`);
     res.status(500).json({ message: 'Missing user information' });
     return;
   }
 
-  const userData = {
-    gid: req.guser.uid,
-    name: req.guser.displayName,
-    email: req.guser.email,
-    nickname: userCreate.nickname,
-  };
+  const userData = { gid, name, email, nickname: userCreate.nickname };
 
   const userDoc = new UserModel(userData);
   await userDoc.save();

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,11 +1,11 @@
 import { type UUID } from 'crypto';
 
-import { type UserRecord } from 'firebase-admin/auth';
+import { type DecodedIdToken } from 'firebase-admin/auth';
 
 declare global {
   declare namespace Express {
     export interface Request {
-      guser?: UserRecord;
+      decodedToken?: DecodedIdToken;
       userId?: UUID;
       rawToken?: string;
       limit?: number;

--- a/test/app.ts
+++ b/test/app.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { type UserRecord } from 'firebase-admin/auth';
+import { type DecodedIdToken } from 'firebase-admin/auth';
 
 import { UserModel } from '@/models/user-schema.ts';
 import APIController from '@routers/API-controller.ts';
@@ -8,41 +8,29 @@ const expressApp = express();
 
 expressApp.set('query parser', 'extended');
 
+// Mirror the production auth middleware: verifying the token yields a
+// DecodedIdToken (no getUser round-trip). The `gid` header stands in for a
+// verified token belonging to that user.
 expressApp.use(async (req, res, next) => {
   const gidHeader = req.headers.gid;
   if (typeof gidHeader == 'string') {
-    const guser: UserRecord = {
+    const decodedToken: DecodedIdToken = {
+      aud: 'mock-project',
+      auth_time: 1706174486,
+      exp: 1745000000,
+      iat: 1745000000,
+      iss: 'https://securetoken.google.com/mock-project',
+      sub: gidHeader,
       uid: gidHeader,
       email: 'mock@csie.ntu.edu.tw',
-      emailVerified: true,
-      displayName: 'Mock Person',
-      photoURL: 'https://mock.com/photo.jpg',
-      phoneNumber: undefined,
-      disabled: false,
-      metadata: {
-        creationTime: 'Thu, 25 Jan 2024 09:21:26 GMT',
-        lastSignInTime: 'Wed, 16 Apr 2025 16:38:59 GMT',
-        lastRefreshTime: 'Wed, 16 Apr 2025 18:34:38 GMT',
-        toJSON: () => ({}),
+      email_verified: true,
+      name: 'Mock Person',
+      firebase: {
+        identities: { 'google.com': [gidHeader] },
+        sign_in_provider: 'google.com',
       },
-      providerData: [
-        {
-          uid: '106273168733193938381',
-          displayName: 'Mock Person',
-          email: 'mock@csie.ntu.edu.tw',
-          photoURL: 'https://mock.com/photo.jpg',
-          providerId: 'google.com',
-          phoneNumber: '+886912345678',
-          toJSON: () => ({}),
-        },
-      ],
-      passwordHash: undefined,
-      passwordSalt: undefined,
-      tokensValidAfterTime: 'Thu, 25 Jan 2024 09:21:26 GMT',
-      tenantId: undefined,
-      toJSON: () => ({}),
     };
-    req.guser = guser;
+    req.decodedToken = decodedToken;
     const userId = (await UserModel.findOne({ gid: gidHeader }).exec())?._id;
     req.userId = userId;
   }


### PR DESCRIPTION
The global auth middleware called auth.getUser() on every request carrying a token, a REST round-trip to Firebase on the hot path. The decoded ID token from the local verifyIdToken check already carries uid, email and email_verified, so carry req.decodedToken instead of a full UserRecord and skip the round-trip entirely.