### PR TITLE
fix(rate-limit): trust reverse-proxy hops so limiter keys per client

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -3,6 +3,10 @@ MONGODB_DB_NAME='csie-council-dev'
 
 PORT='3010'
 
+# Number of reverse-proxy hops in front of the app (express `trust proxy`).
+# 1 = one proxy such as nginx; set to 0 only if the app is exposed directly.
+TRUST_PROXY='1'
+
 GOOGLE_APPLICATION_CREDENTIALS='./service-account-file.json'
 
 UPLOADS_DIR='./uploads'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,9 +123,10 @@ an endpoint, request, or response shape, update the matching `openapi/paths/*.ya
 
 `src/config.ts` validates env with Zod and is the source of truth. Required vars:
 `MONGODB_URI`, `MONGODB_DB_NAME`, `PORT`, `GOOGLE_APPLICATION_CREDENTIALS`, `UPLOADS_DIR`,
-`LOGS_DIR`, `FRONTEND_URL`. Defaults live in `.env.default`; override locally in `.env` (dotenv is
-only loaded when `NODE_ENV !== 'production'`). Firebase auth uses `applicationDefault()`, which reads
-the service-account path from `GOOGLE_APPLICATION_CREDENTIALS`.
+`LOGS_DIR`, `FRONTEND_URL`. Optional: `TRUST_PROXY` (number of reverse-proxy hops the app sits
+behind, for express `trust proxy`; default `1`). Defaults live in `.env.default`; override locally
+in `.env` (dotenv is only loaded when `NODE_ENV !== 'production'`). Firebase auth uses
+`applicationDefault()`, which reads the service-account path from `GOOGLE_APPLICATION_CREDENTIALS`.
 
 > In production (`NODE_ENV=production`, as in the Dockerfile) dotenv is **not** loaded — there is no
 > `.env` fallback, so every required var must be present in the real environment, and

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,10 @@ const EnvSchema = z.object({
   UPLOADS_DIR: z.string(),
   LOGS_DIR: z.string(),
   FRONTEND_URL: z.url(),
+  // Number of reverse-proxy hops in front of the app (express `trust proxy`).
+  // Trust the exact hop count so the rate limiter keys on the real client IP,
+  // never more — trusting extra hops lets clients spoof `X-Forwarded-For`.
+  TRUST_PROXY: z.coerce.number().int().nonnegative().default(1),
 });
 
 const parsed = EnvSchema.safeParse(process.env);

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,9 +14,6 @@ const EnvSchema = z.object({
   UPLOADS_DIR: z.string(),
   LOGS_DIR: z.string(),
   FRONTEND_URL: z.url(),
-  // Number of reverse-proxy hops in front of the app (express `trust proxy`).
-  // Trust the exact hop count so the rate limiter keys on the real client IP,
-  // never more — trusting extra hops lets clients spoof `X-Forwarded-For`.
   TRUST_PROXY: z.coerce.number().int().nonnegative().default(1),
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,10 +52,10 @@ const limiter = rateLimit({
 
 const corsOptions = { origin: env.FRONTEND_URL, credentials: true };
 
-// Log every request (including 429s), then rate-limiter protects everything else.
+// Log every request (including 429s), then apply CORS, finally apply rate limiting to protect everything else.
 expressApp.use(morganMiddleware);
-expressApp.use(limiter);
 expressApp.use(cors(corsOptions));
+expressApp.use(limiter);
 expressApp.use(cookieParser());
 expressApp.use(express.json({ limit: '10mb' }));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,8 +31,6 @@ const expressApp = express();
 
 expressApp.set('query parser', 'extended');
 
-// Trust exactly the configured number of reverse-proxy hops so the rate limiter
-// and `req.ip` key on the real client IP instead of the proxy's shared address.
 expressApp.set('trust proxy', env.TRUST_PROXY);
 
 const stream: StreamOptions = {
@@ -54,8 +52,7 @@ const limiter = rateLimit({
 
 const corsOptions = { origin: env.FRONTEND_URL, credentials: true };
 
-// Log every request (including 429s), then rate-limit before parsing bodies so
-// over-limit clients can't force a large JSON body parse.
+// Log every request (including 429s), then rate-limiter protects everything else.
 expressApp.use(morganMiddleware);
 expressApp.use(limiter);
 expressApp.use(cors(corsOptions));

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ const limiter = rateLimit({
 
 const corsOptions = { origin: env.FRONTEND_URL, credentials: true };
 
-// Log every request (including 429s), then apply CORS, finally apply rate limiting to protect everything else.
+// Log every request (including 429s), then apply CORS and rate limiting before parsing cookies/JSON.
 expressApp.use(morganMiddleware);
 expressApp.use(cors(corsOptions));
 expressApp.use(limiter);

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,11 +31,9 @@ const expressApp = express();
 
 expressApp.set('query parser', 'extended');
 
-expressApp.use(express.json({ limit: '10mb' }));
-
-const corsOptions = { origin: env.FRONTEND_URL, credentials: true };
-expressApp.use(cors(corsOptions));
-expressApp.use(cookieParser());
+// Trust exactly the configured number of reverse-proxy hops so the rate limiter
+// and `req.ip` key on the real client IP instead of the proxy's shared address.
+expressApp.set('trust proxy', env.TRUST_PROXY);
 
 const stream: StreamOptions = {
   write: (message: string) => logger.info(message.trim()), // Log HTTP requests using Winston
@@ -46,8 +44,6 @@ const morganMiddleware = morgan(
   { stream },
 );
 
-expressApp.use(morganMiddleware);
-
 // Limit each IP to 100 requests per minute
 const limiter = rateLimit({
   windowMs: 60 * 1000,
@@ -56,7 +52,15 @@ const limiter = rateLimit({
   legacyHeaders: false,
 });
 
+const corsOptions = { origin: env.FRONTEND_URL, credentials: true };
+
+// Log every request (including 429s), then rate-limit before parsing bodies so
+// over-limit clients can't force a large JSON body parse.
+expressApp.use(morganMiddleware);
 expressApp.use(limiter);
+expressApp.use(cors(corsOptions));
+expressApp.use(cookieParser());
+expressApp.use(express.json({ limit: '10mb' }));
 
 expressApp.use(async (req, res, next) => {
   const authHeader = req.headers.authorization;


### PR DESCRIPTION
Behind a reverse proxy every request arrives with the proxy's IP, so express-rate-limit lumped all users into one 100 req/min bucket. Set trust proxy from a new TRUST_PROXY env var (default 1, one nginx hop) so the limiter keys on the real client IP via X-Forwarded-For.

Also move the limiter ahead of the JSON body parser so over-limit clients can't force a large body parse.