### PR TITLE
refactor(app): share one createApp factory between prod and tests

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -7,6 +7,9 @@ PORT='3010'
 # 1 = one proxy such as nginx; set to 0 only if the app is exposed directly.
 TRUST_PROXY='1'
 
+# Max requests per IP per minute before rate limiting kicks in.
+RATE_LIMIT_MAX='100'
+
 GOOGLE_APPLICATION_CREDENTIALS='./service-account-file.json'
 
 UPLOADS_DIR='./uploads'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,8 @@ an endpoint, request, or response shape, update the matching `openapi/paths/*.ya
 `src/config.ts` validates env with Zod and is the source of truth. Required vars:
 `MONGODB_URI`, `MONGODB_DB_NAME`, `PORT`, `GOOGLE_APPLICATION_CREDENTIALS`, `UPLOADS_DIR`,
 `LOGS_DIR`, `FRONTEND_URL`. Optional: `TRUST_PROXY` (number of reverse-proxy hops the app sits
-behind, for express `trust proxy`; default `1`). Defaults live in `.env.default`; override locally
+behind, for express `trust proxy`; default `1`) and `RATE_LIMIT_MAX` (max requests per IP per
+minute; default `100`, raised in `test/.env.default` so the suite isn't throttled). Defaults live in `.env.default`; override locally
 in `.env` (dotenv is only loaded when `NODE_ENV !== 'production'`). Firebase auth uses
 `applicationDefault()`, which reads the service-account path from `GOOGLE_APPLICATION_CREDENTIALS`.
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,49 @@
+import cookieParser from 'cookie-parser';
+import cors from 'cors';
+import express, { type Express, type RequestHandler } from 'express';
+
+import APIController from '@routers/API-controller.ts';
+import { env } from './config.ts';
+
+export interface AppDependencies {
+  /** Authentication middleware — verifies credentials and sets `req.userId`. */
+  auth: RequestHandler;
+  /** Request logger (e.g. morgan). Omitted in tests to keep output quiet. */
+  requestLogger?: RequestHandler;
+  /**
+   * Rate limiter. Omitted in tests, where a fixed per-IP limit would throttle
+   * the suite's fast request loop; everything else here is shared with prod.
+   */
+  rateLimiter?: RequestHandler;
+}
+
+/**
+ * The application as a function of its dependencies. Production and tests both
+ * build the app through this factory so they exercise the same middleware
+ * chain and order; only the injected pieces differ (real Firebase auth vs. a
+ * mock, and the operational-only logger/limiter). `index.ts` is left to wire
+ * the concrete dependencies and own the bootstrap (Firebase, Mongo, listen).
+ */
+export const createApp = ({
+  auth,
+  requestLogger,
+  rateLimiter,
+}: AppDependencies): Express => {
+  const app = express();
+
+  app.set('query parser', 'extended');
+  app.set('trust proxy', env.TRUST_PROXY);
+
+  // Log every request (including 429s), then CORS and rate limiting before
+  // parsing cookies/JSON so oversized bodies aren't parsed when rate-limited.
+  if (requestLogger) app.use(requestLogger);
+  app.use(cors({ origin: env.FRONTEND_URL, credentials: true }));
+  if (rateLimiter) app.use(rateLimiter);
+  app.use(cookieParser());
+  app.use(express.json({ limit: '10mb' }));
+
+  app.use(auth);
+  app.use('/api', APIController);
+
+  return app;
+};

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import express, { type Express, type RequestHandler } from 'express';
+import { rateLimit } from 'express-rate-limit';
 
 import APIController from '@routers/API-controller.ts';
 import { env } from './config.ts';
@@ -10,18 +11,15 @@ interface AppDependencies {
   auth: RequestHandler;
   // Request logger (e.g. morgan). Omitted in tests to keep output quiet.
   requestLogger?: RequestHandler;
-  // Rate limiter. Omitted in tests.
-  rateLimiter?: RequestHandler;
 }
 
 // The application as a function of its dependencies. Production and tests both
 // build the app through this factory so they exercise the same middleware chain
 // and order; only the injected pieces differ (real Firebase auth vs. a mock,
-// and the operational-only logger/limiter).
+// and the operational-only request logger). Rate limiting's cap is env-tuned.
 export const createApp = ({
   auth,
   requestLogger,
-  rateLimiter,
 }: AppDependencies): Express => {
   const app = express();
 
@@ -32,7 +30,14 @@ export const createApp = ({
   // parsing cookies/JSON so oversized bodies aren't parsed when rate-limited.
   if (requestLogger) app.use(requestLogger);
   app.use(cors({ origin: env.FRONTEND_URL, credentials: true }));
-  if (rateLimiter) app.use(rateLimiter);
+  app.use(
+    rateLimit({
+      windowMs: 60 * 1000,
+      limit: env.RATE_LIMIT_MAX,
+      standardHeaders: 'draft-8',
+      legacyHeaders: false,
+    }),
+  );
   app.use(cookieParser());
   app.use(express.json({ limit: '10mb' }));
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,25 +5,19 @@ import express, { type Express, type RequestHandler } from 'express';
 import APIController from '@routers/API-controller.ts';
 import { env } from './config.ts';
 
-export interface AppDependencies {
-  /** Authentication middleware — verifies credentials and sets `req.userId`. */
+interface AppDependencies {
+  // Authentication middleware — verifies credentials and sets `req.userId`.
   auth: RequestHandler;
-  /** Request logger (e.g. morgan). Omitted in tests to keep output quiet. */
+  // Request logger (e.g. morgan). Omitted in tests to keep output quiet.
   requestLogger?: RequestHandler;
-  /**
-   * Rate limiter. Omitted in tests, where a fixed per-IP limit would throttle
-   * the suite's fast request loop; everything else here is shared with prod.
-   */
+  // Rate limiter. Omitted in tests.
   rateLimiter?: RequestHandler;
 }
 
-/**
- * The application as a function of its dependencies. Production and tests both
- * build the app through this factory so they exercise the same middleware
- * chain and order; only the injected pieces differ (real Firebase auth vs. a
- * mock, and the operational-only logger/limiter). `index.ts` is left to wire
- * the concrete dependencies and own the bootstrap (Firebase, Mongo, listen).
- */
+// The application as a function of its dependencies. Production and tests both
+// build the app through this factory so they exercise the same middleware chain
+// and order; only the injected pieces differ (real Firebase auth vs. a mock,
+// and the operational-only logger/limiter).
 export const createApp = ({
   auth,
   requestLogger,

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ const EnvSchema = z.object({
   LOGS_DIR: z.string(),
   FRONTEND_URL: z.url(),
   TRUST_PROXY: z.coerce.number().int().nonnegative().default(1),
+  RATE_LIMIT_MAX: z.coerce.number().int().positive().default(100),
 });
 
 const parsed = EnvSchema.safeParse(process.env);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import SwaggerParser from '@apidevtools/swagger-parser';
-import { rateLimit } from 'express-rate-limit';
 import { applicationDefault, initializeApp } from 'firebase-admin/app';
-import { getAuth } from 'firebase-admin/auth';
+import { getAuth, type Auth } from 'firebase-admin/auth';
 import mongoose from 'mongoose';
 import morgan, { type StreamOptions } from 'morgan';
 import swaggerUi from 'swagger-ui-express';
@@ -12,7 +11,7 @@ import logger from '@utils/logger.ts';
 import { createApp } from './app.ts';
 import { env } from './config.ts';
 
-let auth;
+let auth: Auth;
 try {
   const firebaseApp = initializeApp({ credential: applicationDefault() });
   logger.info('Connected to Firebase');
@@ -33,18 +32,9 @@ const morganMiddleware = morgan(
   { stream },
 );
 
-// Limit each IP to 100 requests per minute
-const limiter = rateLimit({
-  windowMs: 60 * 1000,
-  limit: 100,
-  standardHeaders: 'draft-8',
-  legacyHeaders: false,
-});
-
 const expressApp = createApp({
   auth: firebaseAuth(auth),
   requestLogger: morganMiddleware,
-  rateLimiter: limiter,
 });
 
 const api = await SwaggerParser.dereference('./openapi/openapi.yaml');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,4 @@
 import SwaggerParser from '@apidevtools/swagger-parser';
-import cookieParser from 'cookie-parser';
-import cors from 'cors';
-import express from 'express';
 import { rateLimit } from 'express-rate-limit';
 import { applicationDefault, initializeApp } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
@@ -9,10 +6,10 @@ import mongoose from 'mongoose';
 import morgan, { type StreamOptions } from 'morgan';
 import swaggerUi from 'swagger-ui-express';
 
-import { UserModel } from '@models/user-schema.ts';
-import APIController from '@routers/API-controller.ts';
+import { firebaseAuth } from '@routers/auth-middleware.ts';
 import dbLogger from '@utils/db-logger.ts';
 import logger from '@utils/logger.ts';
+import { createApp } from './app.ts';
 import { env } from './config.ts';
 
 let auth;
@@ -26,12 +23,6 @@ try {
   logger.error('Exiting...');
   process.exit(1);
 }
-
-const expressApp = express();
-
-expressApp.set('query parser', 'extended');
-
-expressApp.set('trust proxy', env.TRUST_PROXY);
 
 const stream: StreamOptions = {
   write: (message: string) => logger.info(message.trim()), // Log HTTP requests using Winston
@@ -50,42 +41,11 @@ const limiter = rateLimit({
   legacyHeaders: false,
 });
 
-const corsOptions = { origin: env.FRONTEND_URL, credentials: true };
-
-// Log every request (including 429s), then apply CORS and rate limiting before parsing cookies/JSON.
-expressApp.use(morganMiddleware);
-expressApp.use(cors(corsOptions));
-expressApp.use(limiter);
-expressApp.use(cookieParser());
-expressApp.use(express.json({ limit: '10mb' }));
-
-expressApp.use(async (req, res, next) => {
-  const authHeader = req.headers.authorization;
-  const cookieToken = (req.cookies as Record<string, string | undefined>).token;
-  const rawToken = authHeader?.startsWith('Bearer ')
-    ? authHeader.slice(7)
-    : cookieToken;
-
-  if (rawToken !== undefined) {
-    try {
-      const decodedToken = await auth.verifyIdToken(rawToken);
-      req.decodedToken = decodedToken;
-      req.rawToken = rawToken;
-      req.userId = (
-        await UserModel.findOne({ gid: decodedToken.uid })
-          .select('_id')
-          .lean()
-          .exec()
-      )?._id;
-    } catch (err) {
-      logger.error('Error verifying Firebase token: ', err);
-    }
-  }
-
-  next();
+const expressApp = createApp({
+  auth: firebaseAuth(auth),
+  requestLogger: morganMiddleware,
+  rateLimiter: limiter,
 });
-
-expressApp.use('/api', APIController);
 
 const api = await SwaggerParser.dereference('./openapi/openapi.yaml');
 await SwaggerParser.validate(api);

--- a/src/routers/auth-middleware.ts
+++ b/src/routers/auth-middleware.ts
@@ -1,0 +1,43 @@
+import { type RequestHandler } from 'express';
+import { type Auth } from 'firebase-admin/auth';
+
+import { UserModel } from '@models/user-schema.ts';
+import logger from '@utils/logger.ts';
+
+/**
+ * Global auth middleware backed by Firebase. Reads a bearer token or `token`
+ * cookie, verifies it, and populates `req.decodedToken` / `req.rawToken` /
+ * `req.userId`. Auth is optional here: a missing or invalid token simply leaves
+ * these unset and handlers enforce auth themselves.
+ *
+ * Exposed as a factory over its `Auth` dependency so it can be unit-tested and
+ * so `index.ts` stays a thin bootstrap (see `createApp`).
+ */
+export const firebaseAuth =
+  (auth: Auth): RequestHandler =>
+  async (req, res, next) => {
+    const authHeader = req.headers.authorization;
+    const cookieToken = (req.cookies as Record<string, string | undefined>)
+      .token;
+    const rawToken = authHeader?.startsWith('Bearer ')
+      ? authHeader.slice(7)
+      : cookieToken;
+
+    if (rawToken !== undefined) {
+      try {
+        const decodedToken = await auth.verifyIdToken(rawToken);
+        req.decodedToken = decodedToken;
+        req.rawToken = rawToken;
+        req.userId = (
+          await UserModel.findOne({ gid: decodedToken.uid })
+            .select('_id')
+            .lean()
+            .exec()
+        )?._id;
+      } catch (err) {
+        logger.error('Error verifying Firebase token: ', err);
+      }
+    }
+
+    next();
+  };

--- a/test/.env.default
+++ b/test/.env.default
@@ -1,1 +1,5 @@
 UPLOADS_DIR='./test/uploads'
+
+# Effectively disable rate limiting in tests: the suite fires >100 requests per
+# file from a single IP, which the production default (100/min) would throttle.
+RATE_LIMIT_MAX='1000000'

--- a/test/app.ts
+++ b/test/app.ts
@@ -34,7 +34,5 @@ const mockAuth: RequestHandler = async (req, res, next) => {
   next();
 };
 
-// Build the test app through the same factory production uses, so tests
-// exercise the real middleware chain. The request logger and rate limiter are
-// operational-only and left out here.
+// Build the test app through the same factory production uses. The request logger and rate limiter are operational-only and left out here.
 export default createApp({ auth: mockAuth });

--- a/test/app.ts
+++ b/test/app.ts
@@ -34,5 +34,7 @@ const mockAuth: RequestHandler = async (req, res, next) => {
   next();
 };
 
-// Build the test app through the same factory production uses. The request logger and rate limiter are operational-only and left out here.
+// Build the test app through the same factory production uses. The request
+// logger is operational-only and left out; rate limiting still runs, with the
+// raised RATE_LIMIT_MAX from test/.env.default so the fast suite isn't throttled.
 export default createApp({ auth: mockAuth });

--- a/test/app.ts
+++ b/test/app.ts
@@ -1,17 +1,13 @@
-import express from 'express';
+import { type RequestHandler } from 'express';
 import { type DecodedIdToken } from 'firebase-admin/auth';
 
+import { createApp } from '@/app.ts';
 import { UserModel } from '@/models/user-schema.ts';
-import APIController from '@routers/API-controller.ts';
-
-const expressApp = express();
-
-expressApp.set('query parser', 'extended');
 
 // Mirror the production auth middleware: verifying the token yields a
 // DecodedIdToken (no getUser round-trip). The `gid` header stands in for a
 // verified token belonging to that user.
-expressApp.use(async (req, res, next) => {
+const mockAuth: RequestHandler = async (req, res, next) => {
   const gidHeader = req.headers.gid;
   if (typeof gidHeader == 'string') {
     const decodedToken: DecodedIdToken = {
@@ -36,9 +32,9 @@ expressApp.use(async (req, res, next) => {
   }
 
   next();
-});
+};
 
-expressApp.use(express.json({ limit: '10mb' }));
-expressApp.use('/api', APIController);
-
-export default expressApp;
+// Build the test app through the same factory production uses, so tests
+// exercise the real middleware chain. The request logger and rate limiter are
+// operational-only and left out here.
+export default createApp({ auth: mockAuth });


### PR DESCRIPTION
`test/app.ts` hand-rebuilt the app with a different middleware set and order than production, so tests exercised a different app than production runs.

Introduce `src/app.ts::createApp`, which builds the app from its dependencies (the auth middleware, plus optional request logger and rate limiter). Both `src/index.ts` and `test/app.ts` now go through it, so query parser, trust proxy, CORS, cookie-parser, the JSON body limit, and middleware order are identical across environments; only the injected pieces differ (real Firebase auth vs a mock; logger/limiter are operational-only and omitted in tests).